### PR TITLE
+ create data path if not exists - java role dependency

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -11,6 +11,3 @@ galaxy_info:
   categories:
     - clustering
     - queue
-
-dependencies:
-  - idealista.java-role

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -47,3 +47,11 @@
     dest: /lib/systemd/system/kafka.service
     mode: 0644
   notify: restart kafka
+
+- name: KAFKA | Create data path
+  file:
+    path: '{{ kafka_data_path }}'
+    mode: 0760
+    state: directory
+    owner: "{{ kafka_user }}"
+    group: "{{ kafka_user }}"

--- a/templates/server.properties.j2
+++ b/templates/server.properties.j2
@@ -117,3 +117,7 @@ zookeeper.connect={{ kafka_zookeeper_hosts | join(',') }}
 
 # Timeout in ms for connecting to zookeeper
 zookeeper.connection.timeout.ms={{ kafka_zookeeper_connection_timeout_ms }}
+
+############################# Topic configuration #############################
+
+delete.topic.enable={{ kafka_delete_topic_enable }}

--- a/templates/server.properties.j2
+++ b/templates/server.properties.j2
@@ -125,7 +125,3 @@ zookeeper.connect={{ kafka_zookeeper_hosts | join(',') }}
 
 # Timeout in ms for connecting to zookeeper
 zookeeper.connection.timeout.ms={{ kafka_zookeeper_connection_timeout_ms }}
-
-############################# Topic configuration #############################
-
-delete.topic.enable={{ kafka_delete_topic_enable }}


### PR DESCRIPTION
First points seems obvious. As for the second one, it would be great to remove dependancy so the user can choose which Java role he want's to use in a playbook