### PR TITLE
fix for KAFKA_HEAP_OPTS

### DIFF
--- a/templates/kafka.service.j2
+++ b/templates/kafka.service.j2
@@ -5,7 +5,7 @@ After=network.target
 [Service]
 Restart=on-failure
 Environment=KAFKA_LOG4J_OPTS=-Dlog4j.configuration=file:{{ kafka_conf_path }}/log4j.properties
-Environment=KAFKA_HEAP_OPTS=-Xmx{{ kafka_xmx }} -Xms{{ kafka_xms }}
+Environment=KAFKA_HEAP_OPTS="-Xmx{{ kafka_xmx }} -Xms{{ kafka_xms }}"
 Environment=JMX_PORT={{ kafka_jmx_port }}
 ExecStart={{ kafka_install_path }}/bin/kafka-server-start.sh {{ kafka_conf_path }}/server.properties
 ExecStop={{ kafka_install_path }}/bin/kafka-server-stop.sh


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions
* Remember to set **idealista:develop** as base branch;

### Description of the Change
This is fix for "systemd[1]: [/lib/systemd/system/kafka.service:8] Invalid environment assignment, ignoring: KAFKA_HEAP_OPTS=-Xmx1972m -Xms1972m"

### Benefits
correct /etc/kafka/server.properties

### Possible Drawbacks
NA

### Applicable Issues
NA